### PR TITLE
Update emptyElement helper to use replaceChildren

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -10,8 +10,4 @@ export const insertHTML = (el, markup) => {
 	el.insertAdjacentHTML('afterbegin', markup);
 }
 
-export const emptyElement = el => {
-    while (el.hasChildNodes()) {
-		el.removeChild(el.lastChild);
-	}
-}
+export const emptyElement = el => el.replaceChildren()


### PR DESCRIPTION
This changes the `emptyElement` helper to use `replaceChildren`. ([mdn reference](https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren))

This change intends to improve code readability, require one less DOM ‘trick’, and generally reduce the overall lines of code.

Full browser support is circa 2020. ([caniuse reference](https://caniuse.com/?search=replaceChildren))

This change was inspired by this excellent blog post. ([frontendmasters reference](https://frontendmasters.com/blog/vanilla-javascript-todomvc/))