### PR TITLE
Replace blur with focusout

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -84,7 +84,7 @@ const App = {
 				App.render();
 			}
 		});
-		App.todoEvent("blur", '[data-todo="edit"]', (todo, $li, e) => {
+		App.todoEvent("focusout", '[data-todo="edit"]', (todo, $li, e) => {
 			const title = $li.querySelector('[data-todo="edit"]').value;
 			Todos.update({ ...todo, title });
 		});


### PR DESCRIPTION
The `blur` event doesn't bubble, so the event delegation is currently broken. Replacing with `focusout` fixes it.

https://developer.mozilla.org/en-US/docs/Web/API/Element/focusout_event